### PR TITLE
Added <remove-hook> capability

### DIFF
--- a/src/Commands/Desktop/RemoveApp.cs
+++ b/src/Commands/Desktop/RemoveApp.cs
@@ -1,7 +1,13 @@
 // Copyright Bastian Eicher et al.
 // Licensed under the GNU Lesser Public License
 
+using System.Diagnostics;
 using ZeroInstall.DesktopIntegration;
+using ZeroInstall.Model.Capabilities;
+using ZeroInstall.Model.Selection;
+using ZeroInstall.Services;
+using ZeroInstall.Services.Solvers;
+using ZeroInstall.Store.Configuration;
 
 namespace ZeroInstall.Commands.Desktop;
 
@@ -31,6 +37,19 @@ public class RemoveApp : AppCommand
             return ExitCode.NoChanges;
         }
 
+        foreach (var hook in appEntry.CapabilityLists.CompatibleCapabilities().OfType<RemoveHook>())
+        {
+            var process = StartRemoveHook(hook);
+            if (process == null) continue;
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Log.Info($"Remove process for {InterfaceUri} cancelled by remove hook {hook.ID}");
+                return (ExitCode)process.ExitCode;
+            }
+        }
+
         IntegrationManager.RemoveApp(appEntry);
 
         if (ZeroInstallInstance.IsLibraryMode
@@ -42,5 +61,48 @@ public class RemoveApp : AppCommand
         }
 
         return ExitCode.OK;
+    }
+
+    /// <summary>
+    /// Starts a remove <paramref name="hook"/> if the app is already cached.
+    /// </summary>
+    /// <returns>The running hook; <c>null</c> if the app was not cached.</returns>
+    private Process? StartRemoveHook(RemoveHook hook)
+    {
+        if (Handler.Verbosity == Verbosity.Batch)
+        {
+            Log.Info($"Skipped remove hook {hook.ID} for {InterfaceUri} because running in batch mode");
+            return null;
+        }
+
+        Log.Debug($"Solving remove hook {hook.ID} for {InterfaceUri}");
+        var selections = SolveOffline(hook.Command);
+        if (selections == null)
+        {
+            Log.Info($"Skipped remove hook {hook.ID} for {InterfaceUri} because the app is not cached");
+            return null;
+        }
+
+        return Executor.Inject(selections)
+                       .AddArguments(hook.Arguments.Select(x => x.Value).ToArray())
+                       .Start();
+    }
+
+    /// <summary>
+    /// Trys to generate <see cref="Selections"/> for running the specified <paramref name="command"/> without downloading anything.
+    /// </summary>
+    private Selections? SolveOffline(string? command)
+    {
+        Config.NetworkUse = NetworkLevel.Offline;
+        try
+        {
+            var selections = Solver.Solve(new(InterfaceUri, command));
+            return SelectionsManager.GetUncachedImplementations(selections).Any() ? null : selections;
+        }
+        catch (Exception ex) when (ex is SolverException or WebException)
+        {
+            Log.Debug(ex);
+            return null;
+        }
     }
 }

--- a/src/Model/Capabilities/CapabilityList.cs
+++ b/src/Model/Capabilities/CapabilityList.cs
@@ -34,7 +34,14 @@ public sealed partial class CapabilityList : XmlUnknown, ICloneable<CapabilityLi
     /// A list of <see cref="Capability"/>s.
     /// </summary>
     [Browsable(false)]
-    [XmlElement(typeof(AppRegistration)), XmlElement(typeof(AutoPlay)), XmlElement(typeof(ComServer)), XmlElement(typeof(ContextMenu)), XmlElement(typeof(DefaultProgram)), XmlElement(typeof(FileType)), XmlElement(typeof(UrlProtocol))]
+    [XmlElement(typeof(AppRegistration)),
+     XmlElement(typeof(FileType)),
+     XmlElement(typeof(UrlProtocol)),
+     XmlElement(typeof(ContextMenu)),
+     XmlElement(typeof(AutoPlay)),
+     XmlElement(typeof(ComServer)),
+     XmlElement(typeof(DefaultProgram)),
+     XmlElement(typeof(RemoveHook))]
     [OrderedEquality]
     public List<Capability> Entries { get; } = new();
 

--- a/src/Model/Capabilities/RemoveHook.cs
+++ b/src/Model/Capabilities/RemoveHook.cs
@@ -1,0 +1,53 @@
+﻿// Copyright Bastian Eicher et al.
+// Licensed under the GNU Lesser Public License
+
+using ZeroInstall.Model.Design;
+
+namespace ZeroInstall.Model.Capabilities;
+
+/// <summary>
+/// A hook/callback into the application to be called during <c>0install remove</c>.
+/// </summary>
+[Description("A hook/callback into the application to be called during '0install remove'.")]
+[Serializable, XmlRoot("remove-hook", Namespace = CapabilityList.XmlNamespace), XmlType("remove-hook", Namespace = CapabilityList.XmlNamespace)]
+[Equatable]
+public sealed partial class RemoveHook : Capability
+{
+    /// <summary>
+    /// The name of the command in the <see cref="Feed"/> to use when a removal of the app is requested; leave <c>null</c> for <see cref="Model.Command.NameRun"/>.
+    /// </summary>
+    [Description("The name of the command in the feed to use when a removal of the app is requested; leave empty for 'run'.")]
+    [TypeConverter(typeof(CommandNameConverter))]
+    [XmlAttribute("command"), DefaultValue("")]
+    public string? Command { get; set; }
+
+    /// <summary>
+    /// Command-line arguments to be passed to the command. Will be automatically escaped to allow proper concatenation of multiple arguments containing spaces.
+    /// </summary>
+    [Browsable(false)]
+    [XmlElement("arg")]
+    [OrderedEquality]
+    public List<Arg> Arguments { get; } = new();
+
+    /// <inheritdoc/>
+    [Browsable(false), XmlIgnore, IgnoreEquality]
+    public override IEnumerable<string> ConflictIDs => Enumerable.Empty<string>();
+
+    #region Conversion
+    /// <summary>
+    /// Returns the capability in the form "Command". Not safe for parsing!
+    /// </summary>
+    public override string ToString()
+        => $"{Command}";
+    #endregion
+
+    #region Clone
+    /// <inheritdoc/>
+    public override Capability Clone()
+    {
+        var capability = new RemoveHook {UnknownAttributes = UnknownAttributes, UnknownElements = UnknownElements, ID = ID, Command = Command};
+        capability.Arguments.AddRange(Arguments.CloneElements());
+        return capability;
+    }
+    #endregion
+}


### PR DESCRIPTION
This makes it possible for an app to hook into the [`0install remove`](https://docs.0install.net/details/cli/#remove) process and perform shutdown or cleanup logic.

Sample XML in the feed:

```xml
  <capabilities xmlns="http://0install.de/schema/desktop-integration/capabilities">
    <remove-hook id="uninstall">
      <arg>--uninstall</arg>
    </remove-hook>
  </capabilities>
```

Note that the remove hook will only be called if the app is already in the implementation cache.
This avoids the need to fully download an app just to remove it again if it was never actually launched.

Should be merged together with 0install/docs#22