### PR TITLE
Make StubBuilder reference assembly loading lazy

### DIFF
--- a/src/DesktopIntegration/Windows/AppAlias.cs
+++ b/src/DesktopIntegration/Windows/AppAlias.cs
@@ -43,7 +43,18 @@ public static class AppAlias
         PathEnv.AddDir(stubDirPath, machineWide);
 
         string stubFilePath = Paths.Combine(stubDirPath, $"{aliasName}.exe");
-        new StubBuilder(iconStore).BuildRunStub(stubFilePath, target, command, needsTerminal: true);
+        try
+        {
+            new StubBuilder(iconStore).BuildRunStub(stubFilePath, target, command, needsTerminal: true);
+        }
+#if !DEBUG
+        catch (Exception ex)
+        {
+            // Without a stub EXE the alias cannot work; skip it rather than aborting the entire integration.
+            Log.Error($"Failed to generate stub EXE for alias '{aliasName}'.", ex);
+            return;
+        }
+#endif
 
         if (machineWide || WindowsUtils.IsWindows7)
         {

--- a/src/DesktopIntegration/Windows/StubBuilder.cs
+++ b/src/DesktopIntegration/Windows/StubBuilder.cs
@@ -104,12 +104,16 @@ public class StubBuilder(IIconStore iconStore)
         }
     }
 
-    private static readonly string _netFxDirectory = WindowsUtils.GetNetFxDirectory(WindowsUtils.NetFx40);
-
-    private static readonly IEnumerable<PortableExecutableReference> _references =
-        new[] {"mscorlib.dll", "System.dll", "System.Core.dll"}
-           .Select(x => MetadataReference.CreateFromFile(Paths.Combine(_netFxDirectory, x)))
-           .ToList();
+    // Loaded lazily (rather than in a static field initializer) so that a missing reference assembly
+    // surfaces as a regular exception inside BuildRunStub - caught by the fallback in GetRunCommandLine -
+    // instead of a TypeInitializationException thrown when the StubBuilder is constructed.
+    private static readonly Lazy<IReadOnlyList<PortableExecutableReference>> _references = new(() =>
+    {
+        string netFxDirectory = WindowsUtils.GetNetFxDirectory(WindowsUtils.NetFx40);
+        return new[] {"mscorlib.dll", "System.dll", "System.Core.dll"}
+              .Select(x => MetadataReference.CreateFromFile(Paths.Combine(netFxDirectory, x)))
+              .ToList();
+    });
 
     /// <summary>
     /// Builds a stub EXE that executes the <c>0install run</c> command at a specific path.
@@ -138,7 +142,7 @@ public class StubBuilder(IIconStore iconStore)
                     arguments: GetArguments(target.Uri, command, needsTerminal),
                     title: target.Feed.GetBestName(CultureInfo.CurrentUICulture, command))
             ],
-            _references,
+            _references.Value,
             options: new(
                 needsTerminal ? OutputKind.ConsoleApplication : OutputKind.WindowsApplication,
                 optimizationLevel: OptimizationLevel.Release,

--- a/src/DesktopIntegration/Windows/StubBuilder.cs
+++ b/src/DesktopIntegration/Windows/StubBuilder.cs
@@ -104,9 +104,8 @@ public class StubBuilder(IIconStore iconStore)
         }
     }
 
-    // Loaded lazily (rather than in a static field initializer) so that a missing reference assembly
-    // surfaces as a regular exception inside BuildRunStub - caught by the fallback in GetRunCommandLine -
-    // instead of a TypeInitializationException thrown when the StubBuilder is constructed.
+    // Loaded lazily so a missing reference assembly surfaces inside BuildRunStub (where GetRunCommandLine
+    // can fall back) instead of as a TypeInitializationException when the StubBuilder is constructed.
     private static readonly Lazy<IReadOnlyList<PortableExecutableReference>> _references = new(() =>
     {
         string netFxDirectory = WindowsUtils.GetNetFxDirectory(WindowsUtils.NetFx40);


### PR DESCRIPTION
Previously the .NET Framework reference assemblies (mscorlib.dll,
System.dll, System.Core.dll) were loaded in a static field initializer.
If one of those files was missing, the failure surfaced as a
TypeInitializationException thrown when the StubBuilder was constructed,
bypassing the fallback in GetRunCommandLine that is supposed to point
directly at the 0install EXE when stub generation fails.

Load the references lazily so the failure occurs inside BuildRunStub,
where it is caught by the existing fallback logic.